### PR TITLE
43 dtype from csv

### DIFF
--- a/stmtools/_io.py
+++ b/stmtools/_io.py
@@ -67,10 +67,7 @@ def from_csv(
     """
 
     # Load csv as Dask DataFrame
-    _dtypes = pd.read_csv(
-        file, nrows=10
-    ).dtypes.to_dict()  # Get dtypes from first 10 columns
-    ddf = dd.read_csv(file, blocksize=blocksize, dtype=_dtypes)
+    ddf = dd.read_csv(file, blocksize=blocksize)
 
     # Assign default space-time pattern
     if spacetime_pattern is None:

--- a/stmtools/_io.py
+++ b/stmtools/_io.py
@@ -20,7 +20,7 @@ def from_csv(
     space_pattern: str = "^pnt_",
     spacetime_pattern: Dict[str, str] = None,
     coords_cols: List[str] | Dict[str, str] = None,
-    output_chunksize: Dict[str, str] = None,
+    output_chunksize: Dict[str, int] = None,
     blocksize: int | str = 200e6,
 ) -> xr.Dataset:
     """Initiate an STM instance from a csv file.
@@ -111,7 +111,7 @@ def from_csv(
     # Temporaly save time-series columns to lists in dict_temp_da
     for column in ddf.columns:
         if re.match(re.compile(space_pattern), column):
-            if column == 'pnt_id':
+            if column == "pnt_id":
                 # specify str type for point id
                 # otherwise it will be loaded as objest type
                 # then when saving to zarr, a redundant loading is needed to determine type
@@ -162,10 +162,6 @@ def from_csv(
         stmat = stmat.set_coords(coords_cols)
 
     return stmat
-
-
-def _get_col_dtypes():
-    pass
 
 
 def _round_chunksize(size):

--- a/stmtools/_io.py
+++ b/stmtools/_io.py
@@ -8,7 +8,6 @@ from typing import List, Dict
 import logging
 import xarray as xr
 import numpy as np
-import pandas as pd
 import dask.dataframe as dd
 import dask.array as da
 

--- a/stmtools/_io.py
+++ b/stmtools/_io.py
@@ -8,6 +8,7 @@ from typing import List, Dict
 import logging
 import xarray as xr
 import numpy as np
+import pandas as pd
 import dask.dataframe as dd
 import dask.array as da
 
@@ -66,7 +67,10 @@ def from_csv(
     """
 
     # Load csv as Dask DataFrame
-    ddf = dd.read_csv(file, blocksize=blocksize)
+    _dtypes = pd.read_csv(
+        file, nrows=10
+    ).dtypes.to_dict()  # Get dtypes from first 10 columns
+    ddf = dd.read_csv(file, blocksize=blocksize, dtype=_dtypes)
 
     # Assign default space-time pattern
     if spacetime_pattern is None:
@@ -155,6 +159,10 @@ def from_csv(
         stmat = stmat.set_coords(coords_cols)
 
     return stmat
+
+
+def _get_col_dtypes():
+    pass
 
 
 def _round_chunksize(size):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ import stmtools
 import pandas as pd
 import pytest
 from pathlib import Path
+import numpy as np
 
 path_example_csv = Path(__file__).parent / "../examples/data/example.csv"
 
@@ -78,19 +79,30 @@ class TestFromCSV:
         assert data.time.values[0] == pd.Timestamp("2016-03-27T00:00:00.0")
         assert data.time.values[-1] == pd.Timestamp("2016-07-15T00:00:00.0")
         # test if time is in the right order
-        assert (data.time.values[1:] - data.time.values[:-1]).min() > pd.Timedelta(
-            "0s"
-        )
+        assert (data.time.values[1:] - data.time.values[:-1]).min() > pd.Timedelta("0s")
         assert len(data.time.values) == 11
         assert data.time.dtype == "datetime64[ns]"
 
         # test if time are not in correct format
         df = pd.read_csv(path_example_csv)
         # rename a column to make it not in the right format
-        df.rename(columns={
-            "d_20160429": "d_2016/4/29",
-            "a_20160429": "a_2016/4/29",
-            "h2ph_20160429": "h2ph_2016/4/29",}, inplace=True)
+        df.rename(
+            columns={
+                "d_20160429": "d_2016/4/29",
+                "a_20160429": "a_2016/4/29",
+                "h2ph_20160429": "h2ph_2016/4/29",
+            },
+            inplace=True,
+        )
         df.to_csv(tmp_path / "example.csv", index=False)
         data = stmtools.from_csv(tmp_path / "example.csv")
         assert data.time.values[0] == 0
+
+    def test_readcsv_dtypes(self):
+        data = stmtools.from_csv(path_example_csv)
+        data_pd = pd.read_csv(path_example_csv)
+        for key, dtype in dict(data.data_vars.dtypes).items():
+            if key == "pnt_id":
+                dtype.type is np.str_
+            elif "pnt" in key:
+                dtype.type is data_pd.dtypes[key].type


### PR DESCRIPTION
Fix #43 and #44 

Thanks @fnattino for spotting these issues.

Indeed #43 should be caused by the ambiguous dtype. When writing to zarr, the chunk need to be loaded to determine the dtype. I made a fix by loading 10 rows and determine the `dtypes`, then passing it to `daskdataframe.read_csv`.  For `pnt_id`, I specified the data type as `str`. Then there will be no `object` type anymore.

I did the following test. Both the slow loading/warning, and the inconsistent chunksize should have been fixed.

Could you try if it has been fixed?

```py
%%timeit
data = stmtools.from_csv(p_data, blocksize=100e6)
data.to_zarr('data1.zarr', mode='w')
```

```
5.43 s ± 591 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```py
%%timeit
data = stmtools.from_csv(p_data, blocksize=100e6)
data_p = data.persist()
data_p.to_zarr('data2.zarr', mode='w')
```

```
4.87 s ± 160 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

```py
data_chunk = stmtools.from_csv(p_data, blocksize=100e6, output_chunksize={"space":10000, "time":-1})
data_chunk.to_zarr('data_chunk.zarr', mode='w')
data_r = xr.open_zarr('data_chunk.zarr')
data_r
```